### PR TITLE
Some intitial changes to help make this more likely to be approved by flathub

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,14 +9,6 @@ BUILD_DIR := build-dir
 SQUASHFS_ROOT := squashfs-root
 ARCH ?= x86_64
 
-# The user MUST provide these variables when running make
-# Example: make build VERSION=0.25.4 CURSOR_URL=https://.../Cursor-0.25.4.AppImage
-ifndef CURSOR_URL
-    $(error CURSOR_URL is not set. Please provide the download URL for the AppImage.)
-endif
-ifndef VERSION
-    $(error VERSION is not set. Please provide the version number.)
-endif
 
 APPIMAGE_FILE = $(notdir $(CURSOR_URL))
 
@@ -27,13 +19,9 @@ APPIMAGE_FILE = $(notdir $(CURSOR_URL))
 all: build
 
 # Builds the Flatpak. Depends on the AppImage being extracted.
-build: $(SQUASHFS_ROOT)
 	@echo "--> Building the Flatpak..."
 	# Update the version in the appdata file before building
-	sed -i 's/{{VERSION}}/$(VERSION)/g' $(APPDATA)
 	flatpak-builder $(BUILD_DIR) $(MANIFEST) --force-clean
-	# Revert the version change so the template remains clean
-	sed -i 's/$(VERSION)/{{VERSION}}/g' $(APPDATA)
 	@echo "--> Build complete."
 
 # Installs the Flatpak for the current user.

--- a/com.anysphere.Cursor.appdata.xml
+++ b/com.anysphere.Cursor.appdata.xml
@@ -18,7 +18,7 @@
   <launchable type="desktop-id">com.cursor.App.desktop</launchable>
   
   <releases>
-    <release version="{{VERSION}}" date-iso="2025-07-03"/>
+    <release version="1.2.2" date-iso="2025-07-03"/>
   </releases>
 
   <content_rating type="oars-1.1" />

--- a/com.anysphere.Cursor.yml
+++ b/com.anysphere.Cursor.yml
@@ -51,8 +51,12 @@ modules:
     sources:
       - type: file
         dest-filename: Cursor.AppImage
-        url: https://downloads.cursor.com/production/faa03b17cce93e8a80b7d62d57f5eda6bb6ab9fa/linux/x64/Cursor-1.2.2-x86_64.AppImage
+        url: https://www.cursor.com/download/stable/linux-x64
         sha256: 990af540cc38c0ffa41ef13d4563e408ab4739b6ebd23a723b1370dcb7d33df7
+        x-checker-data:
+          type: rotating-url
+          url: https://www.cursor.com/download/stable/linux-x64
+          dest-filename: Cursor.AppImage
       # These are the metadata files from our project directory
       - type: file
         path: com.anysphere.Cursor.desktop

--- a/com.anysphere.Cursor.yml
+++ b/com.anysphere.Cursor.yml
@@ -30,17 +30,21 @@ modules:
   - name: cursor
     buildsystem: simple
     build-commands:
+      - chmod +x ./Cursor.AppImage
+      - ./Cursor.AppImage --appimage-extract
       # Copy the extracted AppImage contents into the /app directory
-      - cp -r usr /app/usr
+      - cp -r squashfs-root/usr /app/usr
       # Install metadata files
       - install -Dm644 com.anysphere.Cursor.desktop /app/share/applications/com.anysphere.Cursor.desktop
       - install -Dm644 com.anysphere.Cursor.appdata.xml /app/share/metainfo/com.anysphere.cursor.appdata.xml
       - install -Dm644 co.anysphere.cursor.png /app/share/icons/hicolor/256x256/apps/com.anysphere.Cursor.png
       - install -Dm755 run.sh /app/bin/zypak-run.sh
+      - rm -rf squashfs-root
     sources:
-      # The Makefile will create this directory before the build starts
-      - type: dir
-        path: squashfs-root
+      - type: file
+        dest-filename: Cursor.AppImage
+        url: https://downloads.cursor.com/production/faa03b17cce93e8a80b7d62d57f5eda6bb6ab9fa/linux/x64/Cursor-1.2.2-x86_64.AppImage
+        sha256: 990af540cc38c0ffa41ef13d4563e408ab4739b6ebd23a723b1370dcb7d33df7
       # These are the metadata files from our project directory
       - type: file
         path: com.anysphere.Cursor.desktop

--- a/com.anysphere.Cursor.yml
+++ b/com.anysphere.Cursor.yml
@@ -37,7 +37,8 @@ modules:
       # Install metadata files
       - install -Dm644 com.anysphere.Cursor.desktop /app/share/applications/com.anysphere.Cursor.desktop
       - install -Dm644 com.anysphere.Cursor.appdata.xml /app/share/metainfo/com.anysphere.cursor.appdata.xml
-      - install -Dm644 co.anysphere.cursor.png /app/share/icons/hicolor/256x256/apps/com.anysphere.Cursor.png
+      - mkdir -p /app/share/icons/hicolor/256x256/apps
+      - ffmpeg -width 256 -i squashfs-root/usr/share/pixmaps/co.anysphere.cursor.png -vf scale=256:-1 -frames:v 1 /app/share/icons/hicolor/256x256/apps/com.anysphere.Cursor.png
       - install -Dm755 run.sh /app/bin/zypak-run.sh
       - rm -rf squashfs-root
     sources:

--- a/com.anysphere.Cursor.yml
+++ b/com.anysphere.Cursor.yml
@@ -6,23 +6,30 @@ command: zypak-run.sh
 base: org.electronjs.Electron2.BaseApp
 base-version: "24.08"
 finish-args:
-  # Basic X11 and Wayland access
-  - --socket=x11
+  - --share=ipc
   - --socket=wayland
+  - --socket=fallback-x11
   # GPU acceleration
   - --device=dri
   # Audio
   - --socket=pulseaudio
+  - --socket=ssh-auth
   # Network access - Cursor needs this for its AI features
   - --share=network
-  # Allow talking to the D-Bus session bus
-  - --socket=session-bus
-  - --socket=system-bus
+  - --device=all
+  - --filesystem=host
+  - --persist=.vscode-oss
+  - --allow=devel
+  - --talk-name=org.freedesktop.secrets
+  - --talk-name=org.kde.kwalletd5
+  - --talk-name=org.freedesktop.Flatpak
+  - --env=XCURSOR_PATH=/run/host/user-share/icons:/run/host/share/icons
+  - --filesystem=xdg-run/gnupg:ro
+  - --filesystem=xdg-config/kdeglobals:ro
+  - --talk-name=com.canonical.AppMenu.Registrar
+  - --system-talk-name=org.freedesktop.login1
+  # Unsure
   - --talk-name=org.freedesktop.Notifications
-  # Deny access to the home directory for security
-  - --nofilesystem=home
-  # Grant access to a specific projects folder
-  - --filesystem=~/cursor-workspace:create
 
 modules:
   # Module for the Cursor application itself

--- a/com.anysphere.Cursor.yml
+++ b/com.anysphere.Cursor.yml
@@ -16,8 +16,6 @@ finish-args:
   - --socket=ssh-auth
   # Network access - Cursor needs this for its AI features
   - --share=network
-  - --device=all
-  - --filesystem=host
   - --persist=.vscode-oss
   - --allow=devel
   - --talk-name=org.freedesktop.secrets

--- a/com.anysphere.Cursor.yml
+++ b/com.anysphere.Cursor.yml
@@ -8,7 +8,7 @@ base-version: "24.08"
 finish-args:
   - --share=ipc
   - --socket=wayland
-  - --socket=fallback-x11
+  - --socket=x11
   # GPU acceleration
   - --device=dri
   # Audio


### PR DESCRIPTION
This PR:
- moves the unpacking of the appimage file into the flatpak manifest itself, making updates as simple as visiting https://www.cursor.com/download/stable/linux-x64 and updating the sha256 hash in the manifest for the downloaded file (if flatpak-builder complains about a hash mismatch)
- Updates the permissions in the `finish-args` based on those from https://github.com/flathub/com.vscodium.codium/blob/master/com.vscodium.codium.yaml (since cursor is a codium fork) - this allows for access to the whole system and session busses to be removed (this is a major red flag to the flathub reviewers)
- sets up x-data-checker so that, if this merges to flathub, their bots should be able to detect when new cursor versions come out and automatically make pull requests


I didnt put much effort into cleaning up the makefile beyond what was needed to make things work - major parts of the makefile are now unused as of this PR and may need to be adjusted, such as:
- removing the `$(SQUASHFS_ROOT): Cursor-$(VERSION)-$(ARCH).AppImage` section and anything relating to `$(SQUASHFS_ROOT`
- adjusting the process for rewriting the version information to allow it to be able to prepend new `<release>` entries into the `*.appdata.xml` file (this would make dealing with new PRs from `x-checker-data` easier